### PR TITLE
Updated Default Version of Spark and Hadoop to CDP 7.2.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val jobServer = Project(id = "job-server", base = file("job-server"))
   .settings(assembly := null.asInstanceOf[File])
   .settings(
     description := "Spark as a Service: a RESTful job server for Apache Spark",
-    libraryDependencies ++= sparkDeps ++ slickDeps ++ cassandraDeps ++
+    libraryDependencies ++= sparkDeps ++ slickDeps ++
     securityDeps ++ coreTestDeps ++ zookeeperDeps ++ miscTestDeps ++ keycloakDeps,
     test in Test := (test in Test).dependsOn(packageBin in Compile in jobServerTestJar)
       .dependsOn(clean in Compile in jobServerTestJar)

--- a/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobManagerActor.scala
@@ -27,7 +27,7 @@ import spark.jobserver.util.{ContextForcefulKillTimeout, StandaloneForcefulKill}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration._
-import org.spark_project.guava.annotations.VisibleForTesting
+import org.sparkproject.guava.annotations.VisibleForTesting
 import spark.jobserver.io.JobDAOActor.{BinaryInfosForCp, BinaryNotFound, GetBinaryInfosForCpFailed}
 
 object JobManagerActor {

--- a/job-server/src/main/scala/spark/jobserver/JobServer.scala
+++ b/job-server/src/main/scala/spark/jobserver/JobServer.scala
@@ -5,9 +5,9 @@ import akka.util.Timeout
 import akka.pattern.ask
 import akka.cluster.Cluster
 import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+
 import java.io.File
 import java.util.concurrent.{TimeUnit, TimeoutException}
-
 import spark.jobserver.io._
 import spark.jobserver.util._
 import org.joda.time.DateTime

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-cluster" % akka exclude("com.typesafe.akka", "akka-remote"),
     "com.typesafe.akka" %% "akka-cluster-tools" % akka,
     "com.typesafe.akka" %% "akka-actor" % akka,
+    "com.typesafe.akka" %% "akka-cluster-typed" % akka,
 
     "com.typesafe.akka" %% "akka-http" % akkaHttp,
     "com.typesafe.akka" %% "akka-http-core" % akkaHttp,
@@ -55,7 +56,10 @@ object Dependencies {
     "com.typesafe.slick" %% "slick" % slick,
     "com.h2database" % "h2" % h2,
     "org.postgresql" % "postgresql" % postgres,
-    "mysql" % "mysql-connector-java" % mysql,
+    "mysql" % "mysql-connector-java" % mysql excludeAll (
+      ExclusionRule("com.google.protobuf",
+        "protobuf-java")
+      ),
     "commons-dbcp" % "commons-dbcp" % commons,
     "org.flywaydb" % "flyway-core" % flyway
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -117,5 +117,7 @@ object Dependencies {
   val repos = Seq(
     "Typesafe Repo" at "https://repo.typesafe.com/typesafe/releases/",
     "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
+    "Cloudera Releases" at "https://repository.cloudera.com/artifactory/libs-release-local/",
+    "Cloudera Staging" at "https://repository.cloudera.com/artifactory/libs-staging-local/"
   )
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,16 +1,16 @@
 import scala.util.Properties.isJavaAtLeast
 
 object Versions {
-  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "2.4.4")
+  lazy val spark = sys.env.getOrElse("SPARK_VERSION", "3.2.1.7.2.15.0-147")
 
-  lazy val akka = "2.5.32"
+  lazy val akka = "2.6.10"
   lazy val akkaHttp = "10.1.13"
   lazy val akkaHttpCors = "0.4.2"
   lazy val cassandra = "3.3.0"
   lazy val commons = "1.4"
   lazy val derby = "10.12.1.1"
   lazy val flyway = "3.2.1"
-  lazy val hadoop = "2.7.3"
+  lazy val hadoop = sys.env.getOrElse("HADOOP_VERSION", "3.1.1.7.2.15.0-147")
   lazy val h2 = "1.3.176"
   lazy val java = sys.env.getOrElse("JAVA_VERSION", "8-jdk")
   lazy val jjwt = "0.9.1"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -21,7 +21,7 @@ object Versions {
   lazy val mesos = sys.env.getOrElse("MESOS_VERSION", "1.0.0-2.0.89.ubuntu1404")
   lazy val metrics = "2.2.0"
   lazy val postgres = "9.4.1209"
-  lazy val mysql = "5.1.42"
+  lazy val mysql = "8.0.23"
   lazy val py4j = "0.10.7"
   lazy val scalaTest = "3.0.1"
   lazy val scalatic = "3.0.1"


### PR DESCRIPTION
Updated these component versions:

1. Spark from 2.4.4 to 3.2.1.7.2.15.0-147
2. Hadoop from 2.7.3 to 3.1.1.7.2.15.0-147
3. Akka from 2.5.32 to 2.6.10